### PR TITLE
Don't persist issue filters accross Runs

### DIFF
--- a/sapp/ui/frontend/src/Runs.js
+++ b/sapp/ui/frontend/src/Runs.js
@@ -38,6 +38,10 @@ function Run(props: $ReadOnly<{run: RunDescription}>): React$Node {
     );
   };
 
+  const clearFilters = () => {
+    window.sessionStorage.removeItem("filter");
+  };
+
   return (
     <>
       <Card
@@ -48,7 +52,11 @@ function Run(props: $ReadOnly<{run: RunDescription}>): React$Node {
             Run {props.run.run_id}
           </>
         }
-        extra={<Link href={`/run/${props.run.run_id}`}>Issues</Link>}>
+        extra={
+          <Link onClick={clearFilters} href={`/run/${props.run.run_id}`}>
+            Issues
+          </Link>
+        }>
         <Row gutter={gutter}>
           <Label>Date</Label>
           <Item>


### PR DESCRIPTION
Don't persist issue filters across runs. Deletes it from the session
storage now when a run is loaded.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
Solves: https://github.com/MLH-Fellowship/pyre-check/issues/33